### PR TITLE
replace error PaymentRequest() w PaymentProtocol()

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -45,7 +45,7 @@ var certificates = new PaymentProtocol().makeX509Certificates();
 certificates.set('certificate', [file_with_x509_der_cert]);
 
 // form the request
-var request = new PaymentRequest().makePaymentRequest();
+var request = new PaymentProtocol().makePaymentRequest();
 request.set('payment_details_version', 1);
 request.set('pki_type', 'x509+sha256');
 request.set('pki_data', certificates.serialize());


### PR DESCRIPTION
Fixing what looks like a typo, because .makePaymentRequest() extends PaymentProtocol's prototype. (https://github.com/bitpay/bitcore-payment-protocol/blob/d4c07cfadf220df0d32110bab4903da114acfdbf/lib/common.js#L216)