### PR TITLE
Fix parsing uint64 fields with values >= 2^32

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -286,7 +286,7 @@ PaymentProtocol.prototype.get = function(key) {
   //protobuf supports longs, javascript naturally does not
   //convert longs (see long.js, e.g. require('long')) to Numbers
   if (typeof v.low !== 'undefined' && typeof v.high !== 'undefined') {
-    return v.toInt();
+    return v.toNumber();
   }
 
   if (typeof v.toBuffer !== 'undefined') {

--- a/test/index.js
+++ b/test/index.js
@@ -128,6 +128,13 @@ describe('PaymentProtocol', function() {
       output.message.get('amount').toInt().should.equal(20);
     });
 
+    it('should be able to get and set amount >= 2^32 through "PaymentProtocol"', function () {
+      var paypro = new PaymentProtocol();
+      paypro.makeOutput();
+      paypro.set('amount', 4294967296);
+      paypro.get('amount').should.equal(4294967296);
+    });
+
   });
 
   describe('#PaymentDetails', function() {


### PR DESCRIPTION
The amount field in an Output message is 64 bits long and is represented
in the JavaScript side using a Long object. When its value is get
through the PaymentProtocol interface, it is parsed using the toInt().
toInt() interprets the Long object as 32 bit so amounts larger than 2^32
will be incorrectly parsed i.e. when an output has an amount larger than
42.9 BTC.

The same issue applies to the PaymentDetails/PaymentRequest messages as
time and expires fields are uint64 too. If time or expires are larger
than 2^32, get operations on those fields will return incorrect values.